### PR TITLE
Add basic Bit model

### DIFF
--- a/db/migrations/20181229204526_create_bits.cr
+++ b/db/migrations/20181229204526_create_bits.cr
@@ -1,0 +1,14 @@
+class CreateBits::V20181229204526 < LuckyRecord::Migrator::Migration::V1
+  def migrate
+    create :bits do
+      add title : String
+      add url : String
+      add description : String?
+      add_belongs_to user : User, on_delete: :cascade
+    end
+  end
+
+  def rollback
+    drop :bits
+  end
+end

--- a/src/actions/bits/index.cr
+++ b/src/actions/bits/index.cr
@@ -1,0 +1,6 @@
+class Bits::Index < BrowserAction
+  route do
+    bits = BitQuery.new.created_at.desc_order
+    render IndexPage, bits: bits
+  end
+end

--- a/src/actions/mixins/auth/redirect_if_signed_in.cr
+++ b/src/actions/mixins/auth/redirect_if_signed_in.cr
@@ -8,7 +8,7 @@ module Auth::RedirectIfSignedIn
   private def redirect_if_signed_in
     if current_user?
       flash.success = "You are already signed in"
-      redirect to: Home::Index
+      redirect to: Me::Show
     else
       continue
     end

--- a/src/actions/sign_ins/create.cr
+++ b/src/actions/sign_ins/create.cr
@@ -6,7 +6,7 @@ class SignIns::Create < BrowserAction
       if authenticated_user
         sign_in(authenticated_user)
         flash.success = "You're now signed in"
-        Authentic.redirect_to_originally_requested_path(self, fallback: Home::Index)
+        Authentic.redirect_to_originally_requested_path(self, fallback: Bits::Index)
       else
         flash.failure = "Sign in failed"
         render NewPage, form: form

--- a/src/actions/sign_ups/create.cr
+++ b/src/actions/sign_ups/create.cr
@@ -6,7 +6,7 @@ class SignUps::Create < BrowserAction
       if user
         flash.info = "Thanks for signing up"
         sign_in(user)
-        redirect to: Home::Index
+        redirect to: Bits::Index
       else
         flash.info = "Couldn't sign you up"
         render NewPage, form: form

--- a/src/app.cr
+++ b/src/app.cr
@@ -1,6 +1,7 @@
 require "./dependencies"
 require "./models/base_model"
 require "./models/mixins/**"
+require "./models/user"
 require "./models/**"
 require "./queries/mixins/**"
 require "./queries/**"

--- a/src/forms/bit_form.cr
+++ b/src/forms/bit_form.cr
@@ -1,0 +1,2 @@
+class BitForm < Bit::BaseForm
+end

--- a/src/models/bit.cr
+++ b/src/models/bit.cr
@@ -1,0 +1,8 @@
+class Bit < BaseModel
+  table :bits do
+    column title : String
+    column url : String
+    column description : String?
+    belongs_to user : User
+  end
+end

--- a/src/pages/bits/index_page.cr
+++ b/src/pages/bits/index_page.cr
@@ -1,0 +1,11 @@
+class Bits::IndexPage < MainLayout
+  needs bits : BitQuery
+
+  def content
+    ul class: "bits" do
+      @bits.each do |bit|
+        link bit.title, to: bit.url
+      end
+    end
+  end
+end

--- a/src/queries/bit_query.cr
+++ b/src/queries/bit_query.cr
@@ -1,0 +1,5 @@
+class BitQuery < Bit::BaseQuery
+  def for_user(user : User)
+    user_id.not(user.id)
+  end
+end


### PR DESCRIPTION
This only display's Bits. You can't create them yet.

I wanted to call the model `Link` but it appears Crystal itself has something called link: an Annotation. I'm not sure what that is yet, but if you try to do this:

```crystal
class Link
end
```

You get an error

```
Link is not a class, it'a an annotation.
```

Searching around the crystal source code I couldn't find many capital `L` links, but it's obviously there somewhere. I went through a couple of other names: websites, shares, weblinks, hyperlinks, but decided on bits. It's short, doesn't really mean anything in this context so it just becomes a domain word.