### PR TITLE
Create a new bit

### DIFF
--- a/src/actions/bits/create.cr
+++ b/src/actions/bits/create.cr
@@ -1,0 +1,11 @@
+class Bits::Create < BrowserAction
+  route do
+    BitForm.create(params, user_id: current_user.id) do |form, bit|
+      if bit
+        render Bits::IndexPage, bits: BitQuery.recently_created
+      else
+        render Bits::NewPage, bit_form: form
+      end
+    end
+  end
+end

--- a/src/actions/bits/index.cr
+++ b/src/actions/bits/index.cr
@@ -1,6 +1,5 @@
 class Bits::Index < BrowserAction
   route do
-    bits = BitQuery.new.created_at.desc_order
-    render IndexPage, bits: bits
+    render IndexPage, bits: BitQuery.recently_created
   end
 end

--- a/src/actions/bits/new.cr
+++ b/src/actions/bits/new.cr
@@ -1,0 +1,5 @@
+class Bits::New < BrowserAction
+  route do
+    render Bits::NewPage, bit_form: BitForm.new
+  end
+end

--- a/src/forms/bit_form.cr
+++ b/src/forms/bit_form.cr
@@ -1,2 +1,5 @@
 class BitForm < Bit::BaseForm
+  fillable title
+  fillable url
+  fillable description
 end

--- a/src/pages/bits/index_page.cr
+++ b/src/pages/bits/index_page.cr
@@ -4,7 +4,9 @@ class Bits::IndexPage < MainLayout
   def content
     ul class: "bits" do
       @bits.each do |bit|
-        link bit.title, to: bit.url
+        li class: "bit" do
+          link bit.title, to: bit.url
+        end
       end
     end
   end

--- a/src/pages/bits/new_page.cr
+++ b/src/pages/bits/new_page.cr
@@ -1,0 +1,39 @@
+class Bits::NewPage < MainLayout
+  needs bit_form : BitForm
+
+  def content
+    render_bit_form(@bit_form)
+  end
+
+  private def render_bit_form(form : BitForm)
+    form_for Bits::Create do
+      div class: "field" do
+        label_and_errors_for(form.title) do |field|
+          text_input field
+        end
+      end
+
+      div class: "field" do
+        label_and_errors_for(form.url) do |field|
+          text_input field
+        end
+      end
+
+      div class: "field" do
+        label_and_errors_for(form.description) do |field|
+          textarea field
+        end
+      end
+
+      div class: "action" do
+        submit "Create Bit"
+      end
+    end
+  end
+
+  private def label_and_errors_for(field)
+    label_for field
+    yield(field)
+    errors_for field
+  end
+end

--- a/src/pages/main_layout.cr
+++ b/src/pages/main_layout.cr
@@ -21,8 +21,9 @@ abstract class MainLayout
   end
 
   private def render_signed_in_user
-    text @current_user.email
-    text " - "
-    link "Sign out", to: SignIns::Delete, flow_id: "sign-out-button"
+    nav do
+      link "Sign out", to: SignIns::Delete, flow_id: "sign-out-button"
+      link "New Bit", to: Bits::New
+    end
   end
 end

--- a/src/queries/bit_query.cr
+++ b/src/queries/bit_query.cr
@@ -1,4 +1,12 @@
 class BitQuery < Bit::BaseQuery
+  def self.recently_created
+    new.recently_created
+  end
+
+  def recently_created
+    created_at.desc_order
+  end
+
   def for_user(user : User)
     user_id.not(user.id)
   end


### PR DESCRIPTION
The `user_id` has to be added inside the action because it would be insecure to pass it as a param. If you could pass it, then anyone could create a bit as any other user just by knowing their ID.