### PR TITLE
Accept pending follow requests

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -50,7 +50,7 @@ shards:
 
   lucky_record:
     github: luckyframework/lucky_record
-    version: 0.7.0
+    commit: 6dfa3e2f801bf810cd4998ec36c9a53f51ab30c2
 
   lucky_router:
     github: luckyframework/lucky_router

--- a/shard.yml
+++ b/shard.yml
@@ -11,6 +11,9 @@ targets:
 crystal: 0.27.0
 
 dependencies:
+  lucky_record:
+    github: luckyframework/lucky_record
+    branch: master
   lucky:
     github: luckyframework/lucky
     version: ~> 0.12

--- a/src/actions/follows/update.cr
+++ b/src/actions/follows/update.cr
@@ -1,0 +1,9 @@
+class Follows::Update < BrowserAction
+  route do
+    follows = FollowQuery.follow_requests(for: current_user)
+    follow = follows.id(params.get(:id)).first
+    FollowAcceptForm.update!(follow)
+    flash.success = "#{follow.from.email} is now following you!"
+    redirect Me::Show
+  end
+end

--- a/src/actions/me/show.cr
+++ b/src/actions/me/show.cr
@@ -1,5 +1,7 @@
 class Me::Show < BrowserAction
   get "/me" do
-    render ShowPage
+    follow_requests = FollowQuery.follow_requests(for: current_user)
+    followers = FollowQuery.followers(for: current_user)
+    render ShowPage, follow_requests: follow_requests, followers: followers
   end
 end

--- a/src/forms/follow_accept_form.cr
+++ b/src/forms/follow_accept_form.cr
@@ -1,0 +1,5 @@
+class FollowAcceptForm < Follow::BaseForm
+  def prepare
+    accepted_at.value = Time.now
+  end
+end

--- a/src/pages/me/show_page.cr
+++ b/src/pages/me/show_page.cr
@@ -1,17 +1,29 @@
 class Me::ShowPage < MainLayout
+  needs follow_requests : FollowQuery
+  needs followers : FollowQuery
+
   def content
-    h1 "This is your profile"
     h3 "Email:  #{@current_user.email}"
-    helpful_tips
+    list_follow_requests(@follow_requests)
+    list_followers(@followers)
   end
 
-  private def helpful_tips
-    h3 "Next, you may want to:"
+  private def list_follow_requests(follow_requests : FollowQuery)
+    h3 "Follow Requests"
     ul do
-      li "Modify this page: src/pages/me/show_page.cr"
-      li "Change what route you go to after sign in: src/actions/home/index.cr"
-      li "To add pages that do not require sign in, include the" +
-         "Auth::SkipRequireSignIn module in your actions"
+      follow_requests.each do |follow|
+        li "#{follow.from.email}"
+        link "Allow", to: Follows::Update.with(follow.id)
+      end
+    end
+  end
+
+  private def list_followers(followers : FollowQuery)
+    h3 "Followers"
+    ul do
+      followers.each do |follow|
+        li "#{follow.from.email}"
+      end
     end
   end
 end

--- a/src/queries/follow_query.cr
+++ b/src/queries/follow_query.cr
@@ -1,2 +1,21 @@
 class FollowQuery < Follow::BaseQuery
+  def self.followers(for user : User)
+    new.followers(for: user)
+  end
+
+  def followers(for user : User)
+    preload_from.
+      where("accepted_at IS NOT NULL").
+      to_id(user.id)
+  end
+
+  def self.follow_requests(for user : User)
+    new.follow_requests(for: user)
+  end
+
+  def follow_requests(for user : User)
+    preload_from.
+      where("accepted_at IS NULL").
+      to_id(user.id)
+  end
 end


### PR DESCRIPTION
The requests come into the `/me` page. Clicking accept will set the `accepted_at` value in the database and consider the follow accepted.

To split up follows by accepted and not accepted, we looked for the `NULL`ness of the `accepted_at` column. If it's `NULL` it has not yet been accepted.

We also had to grab the latest version of lucky_record because of a bug that affected our model. (https://github.com/luckyframework/lucky_record/pull/306).