### PR TITLE
Filter Bits

### DIFF
--- a/src/actions/bits/index.cr
+++ b/src/actions/bits/index.cr
@@ -1,5 +1,5 @@
 class Bits::Index < BrowserAction
   route do
-    render IndexPage, bits: BitQuery.recently_created
+    render IndexPage, bits: BitQuery.followed(by: current_user)
   end
 end

--- a/src/actions/home/index.cr
+++ b/src/actions/home/index.cr
@@ -3,7 +3,7 @@ class Home::Index < BrowserAction
 
   get "/" do
     if current_user?
-      redirect Me::Show
+      redirect Bits::Index
     else
       render Lucky::WelcomePage
     end

--- a/src/models/bit.cr
+++ b/src/models/bit.cr
@@ -4,5 +4,6 @@ class Bit < BaseModel
     column url : String
     column description : String?
     belongs_to user : User
+    has_many follows : Follow, through: :users
   end
 end

--- a/src/models/user.cr
+++ b/src/models/user.cr
@@ -5,6 +5,8 @@ class User < BaseModel
   table :users do
     column email : String
     column encrypted_password : String
+    has_many bits : Bit
+    has_many follows : Follow, foreign_key: :to_id
   end
 
   def emailable

--- a/src/pages/bits/index_page.cr
+++ b/src/pages/bits/index_page.cr
@@ -6,6 +6,7 @@ class Bits::IndexPage < MainLayout
       @bits.each do |bit|
         li class: "bit" do
           link bit.title, to: bit.url
+          para "from: #{bit.user.email}"
         end
       end
     end

--- a/src/queries/bit_query.cr
+++ b/src/queries/bit_query.cr
@@ -10,4 +10,13 @@ class BitQuery < Bit::BaseQuery
   def for_user(user : User)
     user_id.not(user.id)
   end
+
+  def self.followed(by user : User)
+    new.followed(user)
+  end
+
+  def followed(by user : User)
+    inner_join_follows
+    preload_user.follows(&.from_id(user.id).where("accepted_at IS NOT NULL"))
+  end
 end


### PR DESCRIPTION
This required some hooking up of models so that bits could access the
follow model through users. This allows me to filter bits via who the
user is following. I wanted to called it `followed` but I had to call
the association `follows` because the table's name is `follows`. I'll
see if I can fix that later.

I also couldn't use a pre-defined `accepted` method to make sure all
bits I retrieved were only from followed users. I originally had a
method prepared called `accepted` that did a `where("accepted_at IS NOT
NULL")` which works fine on its own. However, when filtering a join (in
this case joining bits fo follows) the block that is passed only has
access to the BaseQuery object, which doesn't have any custom defined
methods.