### PR TITLE
Add Feed Token

### DIFF
--- a/db/migrations/20190111132118_add_feed_token_to_user.cr
+++ b/db/migrations/20190111132118_add_feed_token_to_user.cr
@@ -1,0 +1,13 @@
+class AddFeedTokenToUser::V20190111132118 < LuckyRecord::Migrator::Migration::V1
+  def migrate
+    alter :users do
+      add feed_token : String, fill_existing_with: "invalid-token"
+    end
+  end
+
+  def rollback
+    alter :users do
+      remove :feed_token
+    end
+  end
+end

--- a/src/forms/sign_up_form.cr
+++ b/src/forms/sign_up_form.cr
@@ -3,6 +3,7 @@ class SignUpForm < User::BaseForm
   include PasswordValidations
 
   fillable email
+  fillable feed_token
   virtual password : String
   virtual password_confirmation : String
 
@@ -10,5 +11,10 @@ class SignUpForm < User::BaseForm
     validate_uniqueness_of email
     run_password_validations
     Authentic.copy_and_encrypt password, to: encrypted_password
+    feed_token.value = generate_feed_token
+  end
+
+  private def generate_feed_token
+    Random::Secure.hex(16)
   end
 end

--- a/src/models/user.cr
+++ b/src/models/user.cr
@@ -5,6 +5,7 @@ class User < BaseModel
   table :users do
     column email : String
     column encrypted_password : String
+    column feed_token : String
     has_many bits : Bit
     has_many follows : Follow, foreign_key: :to_id
   end


### PR DESCRIPTION
Since feeds will be private to each user, we need a way to authenticate
and authorize the user through just a parameter in the URL. That
parameter will be this feed token.

Right now since there is no actual production (or staging) site, and
therefore no users, I can get away with filling the token with an
invalid value. During sign up, the token will be set and everything
will be fine.