### PR TITLE
Make a user page

### DIFF
--- a/spec/flows/base_flow.cr
+++ b/spec/flows/base_flow.cr
@@ -1,3 +1,0 @@
-# Add methods that all or most Flows need to share
-class BaseFlow < LuckyFlow
-end

--- a/spec/flows/user_spec.cr
+++ b/spec/flows/user_spec.cr
@@ -1,0 +1,14 @@
+require "../spec_helper"
+
+describe "Visit a user to follow them" do
+  it "has a follow button on the user page" do
+    current_user = UserBox.create(&.email("user@example.com"))
+    flow = UserFlow.new(current_user)
+    existing_user = UserBox.create(&.email("existing@example.com"))
+
+    flow.visit_user_page(existing_user)
+    flow.request_follow
+
+    flow.should_have_flash("Your invite has been sent for approval!")
+  end
+end

--- a/spec/support/flows/user_flow.cr
+++ b/spec/support/flows/user_flow.cr
@@ -1,0 +1,17 @@
+class UserFlow < BaseFlow
+  def initialize(user : User)
+    visit Me::Show, as: user
+  end
+
+  def visit_user_page(user : User)
+    visit Users::Show.with(user.id)
+  end
+
+  def request_follow
+    click "@request-user-follow"
+  end
+
+  def should_have_flash(text)
+    el("@flash", text: text).should be_on_page
+  end
+end

--- a/src/actions/follows/create.cr
+++ b/src/actions/follows/create.cr
@@ -1,6 +1,9 @@
 class Follows::Create < BrowserAction
   route do
-    FollowRequestForm.create(params, current_user: current_user) do |form, follow|
+    FollowRequestEmailForm.create(
+      params: params,
+      current_user: current_user,
+    ) do |form, follow|
       if follow
         flash.success = "Your invite has been sent for approval!"
         redirect Follows::New

--- a/src/actions/follows/new.cr
+++ b/src/actions/follows/new.cr
@@ -1,6 +1,6 @@
 class Follows::New < BrowserAction
   route do
-    form = FollowRequestForm.new(current_user: current_user)
+    form = FollowRequestEmailForm.new(current_user: current_user)
     render Follows::NewPage, follow_request_form: form
   end
 end

--- a/src/actions/users/follows/create.cr
+++ b/src/actions/users/follows/create.cr
@@ -9,7 +9,8 @@ class Users::Follows::Create < BrowserAction
         flash.success = "Your invite has been sent for approval!"
         redirect Users::Show.with(user.id)
       else
-        render Users::ShowPage, user: user
+        flash.failure = "Something went wrong with that follow request..."
+        redirect Users::Show.with(user.id)
       end
     end
   end

--- a/src/actions/users/follows/create.cr
+++ b/src/actions/users/follows/create.cr
@@ -1,0 +1,16 @@
+class Users::Follows::Create < BrowserAction
+  nested_route do
+    user = UserQuery.find(params.get(:user_id))
+    FollowRequestDirectForm.create(
+      current_user: current_user,
+      to_user: user,
+    ) do |form, follow|
+      if follow
+        flash.success = "Your invite has been sent for approval!"
+        redirect Users::Show.with(user.id)
+      else
+        render Users::ShowPage, user: user
+      end
+    end
+  end
+end

--- a/src/actions/users/show.cr
+++ b/src/actions/users/show.cr
@@ -1,6 +1,14 @@
 class Users::Show < BrowserAction
   route do
     user = UserQuery.find(params.get(:id))
-    render Users::ShowPage, user: user
+    existing_follow_requests = FollowQuery.
+      new.
+      from_id(current_user.id).
+      to_id(user.id)
+    render(
+      Users::ShowPage,
+      user: user,
+      existing_follow_requests: existing_follow_requests,
+    )
   end
 end

--- a/src/actions/users/show.cr
+++ b/src/actions/users/show.cr
@@ -1,0 +1,6 @@
+class Users::Show < BrowserAction
+  route do
+    user = UserQuery.find(params.get(:id))
+    render Users::ShowPage, user: user
+  end
+end

--- a/src/forms/follow_request_direct_form.cr
+++ b/src/forms/follow_request_direct_form.cr
@@ -1,0 +1,9 @@
+class FollowRequestDirectForm < Follow::BaseForm
+  needs current_user : User
+  needs to_user : User
+
+  def prepare
+    from_id.value = current_user.id
+    to_id.value = to_user.id
+  end
+end

--- a/src/forms/follow_request_email_form.cr
+++ b/src/forms/follow_request_email_form.cr
@@ -1,4 +1,4 @@
-class FollowRequestForm < Follow::BaseForm
+class FollowRequestEmailForm < Follow::BaseForm
   needs current_user : User
   virtual email : String
 

--- a/src/pages/follows/new_page.cr
+++ b/src/pages/follows/new_page.cr
@@ -1,5 +1,5 @@
 class Follows::NewPage < MainLayout
-  needs follow_request_form : FollowRequestForm
+  needs follow_request_form : FollowRequestEmailForm
 
   def content
     render_follow_request_form(@follow_request_form)

--- a/src/pages/users/show_page.cr
+++ b/src/pages/users/show_page.cr
@@ -1,0 +1,12 @@
+class Users::ShowPage < MainLayout
+  needs user : User
+
+  def content
+    h2 @user.email
+    link(
+      "Request to follow",
+      to: Users::Follows::Create.with(user_id: @user.id),
+      flow_id: "request-user-follow"
+    )
+  end
+end

--- a/src/pages/users/show_page.cr
+++ b/src/pages/users/show_page.cr
@@ -1,11 +1,21 @@
 class Users::ShowPage < MainLayout
   needs user : User
+  needs existing_follow_requests : FollowQuery
 
   def content
     h2 @user.email
+
+    if @existing_follow_requests.try(&.empty?)
+      link_to_follow(@user)
+    else
+      para "We're waiting on #{@user.email} to confirm your follow request."
+    end
+  end
+
+  private def link_to_follow(user : User)
     link(
       "Request to follow",
-      to: Users::Follows::Create.with(user_id: @user.id),
+      to: Users::Follows::Create.with(user_id: user.id),
       flow_id: "request-user-follow"
     )
   end

--- a/src/queries/follow_query.cr
+++ b/src/queries/follow_query.cr
@@ -28,4 +28,8 @@ class FollowQuery < Follow::BaseQuery
       where("accepted_at IS NOT NULL").
       from_id(user.id)
   end
+
+  def empty?
+    size.zero?
+  end
 end


### PR DESCRIPTION
This is extremely minimal and is mostly adding a convenient way to follow users from their profile page.

This uses a new form called `FollowRequestDirectForm`. It's similar to the `FollowRequestEmailForm ` that takes an email (previously named `FollowRequestForm`) but it takes a `User` instead. It relies on the fact that a new action `Users::Follows::Create` is a nested action and will have a `user_id` parameter already present to find a user with.