### PR TITLE
Remove public email

### DIFF
--- a/src/actions/feeds/show.cr
+++ b/src/actions/feeds/show.cr
@@ -7,7 +7,7 @@ class Feeds::Show < FeedAction
     atom(
       feed do |xml|
         xml.element("title") { xml.text "LinkyBits" }
-        xml.element("subtitle") { xml.text "for #{current_user.email}" }
+        xml.element("subtitle") { xml.text "for #{current_user.username}" }
         xml.element(
           "link",
           rel: "alternate",
@@ -55,7 +55,7 @@ class Feeds::Show < FeedAction
       xml.element("published") { xml.text bit.created_at.to_rfc3339 }
       xml.element("updated") { xml.text bit.updated_at.to_rfc3339 }
       xml.element("author") do
-        xml.element("email") { xml.text bit.user.email }
+        xml.element("name") { xml.text bit.user.username }
       end
       xml.element("content", type: "html") do
         xml.text bit.description || ""

--- a/src/actions/follows/update.cr
+++ b/src/actions/follows/update.cr
@@ -3,7 +3,7 @@ class Follows::Update < BrowserAction
     follows = FollowQuery.follow_requests(for: current_user)
     follow = follows.id(params.get(:id)).first
     FollowAcceptForm.update!(follow)
-    flash.success = "#{follow.from.email} is now following you!"
+    flash.success = "#{follow.from.username} is now following you!"
     redirect Follows::Index
   end
 end

--- a/src/components/shared/bit_list.cr
+++ b/src/components/shared/bit_list.cr
@@ -4,7 +4,7 @@ module Shared::BitList
       bits.each do |bit|
         li class: "bit" do
           link bit.title, to: bit.url, flow_id: "bit-title"
-          para "from: #{bit.user.email}"
+          para "from: #{bit.user.username}"
         end
       end
     end

--- a/src/pages/main_layout.cr
+++ b/src/pages/main_layout.cr
@@ -23,8 +23,8 @@ abstract class MainLayout
   private def render_signed_in_user
     nav do
       ul do
-        li { link @current_user.email, to: Me::Show }
-        li { link "Sign out", to: SignIns::Delete, flow_id: "sign-out-button" }
+        li { link "My Page", to: Me::Show }
+        li { link "Sign Out", to: SignIns::Delete, flow_id: "sign-out-button" }
         li { link "New Bit", to: Bits::New, flow_id: "new-bit-link" }
         li { link "Follows", to: Follows::Index }
       end

--- a/src/pages/users/show_page.cr
+++ b/src/pages/users/show_page.cr
@@ -8,7 +8,7 @@ class Users::ShowPage < MainLayout
     if @existing_follow_requests.try(&.empty?)
       link_to_follow(@user)
     else
-      para "We're waiting on #{@user.email} to confirm your follow request."
+      para "We're waiting on #{@user.username} to confirm your follow request."
     end
   end
 

--- a/src/pages/users/show_page.cr
+++ b/src/pages/users/show_page.cr
@@ -3,7 +3,7 @@ class Users::ShowPage < MainLayout
   needs existing_follow_requests : FollowQuery
 
   def content
-    h2 @user.email
+    h2 @user.username
 
     if @existing_follow_requests.try(&.empty?)
       link_to_follow(@user)


### PR DESCRIPTION
Users shouldn't be able to see another user's email. This removes all reference to email any other user would see like:
* The author email in the atom feed (now just using the name instead)
* The list of bits shows who the bit was posted by
* The link to your Me::Show page in the main layout
* The User::Show page title
* When allowing someone to follow you it shows their email for the request and also the success message after allowing them to follow you