### PR TITLE
Follow back a user

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -13,7 +13,7 @@ crystal: 0.27.0
 dependencies:
   lucky_record:
     github: luckyframework/lucky_record
-    branch: master
+    commit: 6dfa3e2f801bf810cd4998ec36c9a53f51ab30c2
   lucky:
     github: luckyframework/lucky
     version: ~> 0.12

--- a/spec/flows/follow_spec.cr
+++ b/spec/flows/follow_spec.cr
@@ -16,4 +16,19 @@ describe "User visits new follow page" do
 
     flow2.should_see_user_in_followers_list(user1)
   end
+
+  context "when accepting a follow request" do
+    it "allows the accepting user to follow back the requesting user" do
+      user1 = UserBox.create(&.email("user1@example.com").username("user1"))
+      user2 = UserBox.create(&.email("user2@example.com").username("user2"))
+      follow = FollowBox.create(&.to_id(user2.id).from_id(user1.id))
+      flow = FollowFlow.new(user: user2)
+
+      flow.visit_follows_page
+      flow.allow_user_to_follow(user: user1)
+      flow.follow_back(user1)
+
+      flow.should_show_follow_request_to(user1)
+    end
+  end
 end

--- a/spec/support/boxes/follow_box.cr
+++ b/spec/support/boxes/follow_box.cr
@@ -1,0 +1,2 @@
+class FollowBox < LuckyRecord::Box
+end

--- a/spec/support/flows/follow_flow.cr
+++ b/spec/support/flows/follow_flow.cr
@@ -25,7 +25,15 @@ class FollowFlow < BaseFlow
     allow_link.click
   end
 
+  def follow_back(user follower : User)
+    click("@follow-back-#{follower.username}")
+  end
+
   def should_see_user_in_followers_list(user following : User)
     el(".followers li", text: following.username)
+  end
+
+  def should_show_follow_request_to(user following : User)
+    el("@flash", text: "Your follow request has been sent to #{following.username} for approval!")
   end
 end

--- a/src/actions/follows/create.cr
+++ b/src/actions/follows/create.cr
@@ -5,7 +5,7 @@ class Follows::Create < BrowserAction
       current_user: current_user,
     ) do |form, follow|
       if follow
-        flash.success = "Your invite has been sent for approval!"
+        flash.success = "Your follow request has been sent to #{follow.to.username} for approval!"
         redirect Follows::New
       else
         render Follows::NewPage, follow_request_form: form

--- a/src/actions/follows/index.cr
+++ b/src/actions/follows/index.cr
@@ -3,11 +3,14 @@ class Follows::Index < BrowserAction
     follow_requests = FollowQuery.follow_requests(for: current_user)
     followers = FollowQuery.followers(for: current_user)
     following = FollowQuery.following(for: current_user)
+    recent_follows = FollowQuery.recent_follows(for: current_user)
+
     render(
       IndexPage,
       follow_requests: follow_requests,
       followers: followers,
-      following: following
+      following: following,
+      recent_follows: recent_follows
     )
   end
 end

--- a/src/pages/follows/index_page.cr
+++ b/src/pages/follows/index_page.cr
@@ -2,12 +2,28 @@ class Follows::IndexPage < MainLayout
   needs follow_requests : FollowQuery
   needs followers : FollowQuery
   needs following : FollowQuery
+  needs recent_follows : FollowQuery
 
   def content
     link "Follow someone", to: Follows::New
+    list_recent_follows(@recent_follows)
     list_follow_requests(@follow_requests)
     list_followers(@followers)
     list_following(@following)
+  end
+
+  private def list_recent_follows(recent_follows : FollowQuery)
+    if !recent_follows.empty?
+      section class: "recent-follows" do
+        recent_follows.each do |follow|
+          link(
+            "Follow #{follow.from.username}",
+            to: Users::Follows::Create.with(user_id: follow.from.id),
+            flow_id: "follow-back-#{follow.from.username}"
+          )
+        end
+      end
+    end
   end
 
   private def list_follow_requests(follow_requests : FollowQuery)

--- a/src/pages/follows/index_page.cr
+++ b/src/pages/follows/index_page.cr
@@ -13,15 +13,13 @@ class Follows::IndexPage < MainLayout
   end
 
   private def list_recent_follows(recent_follows : FollowQuery)
-    if !recent_follows.empty?
+    if follow = recent_follows.first?
       section class: "recent-follows" do
-        recent_follows.each do |follow|
-          link(
-            "Follow #{follow.from.username}",
-            to: Users::Follows::Create.with(user_id: follow.from.id),
-            flow_id: "follow-back-#{follow.from.username}"
-          )
-        end
+        link(
+          "Follow #{follow.from.username}",
+          to: Users::Follows::Create.with(user_id: follow.from.id),
+          flow_id: "follow-back-#{follow.from.username}"
+        )
       end
     end
   end

--- a/src/queries/follow_query.cr
+++ b/src/queries/follow_query.cr
@@ -29,6 +29,14 @@ class FollowQuery < Follow::BaseQuery
       from_id(user.id)
   end
 
+  def self.recent_follows(for user : User)
+    new.
+      preload_from.
+      to_id(user.id).
+      accepted_at.
+      gt(3.minute.ago)
+  end
+
   def empty?
     size.zero?
   end


### PR DESCRIPTION
This presents a way for someone to follow a user back that they just accepted. I couldn't figure out a good way to pass a message that says "follow user2 back?" that only shows up once, right after `user1` accepts `user2`. The only way I could think of was to make an identical action that passed a query to the page that was nilable so the normal index action didn't require it.

Instead, I created a query that checks to see if you accepted someone 3 minutes ago or less and displays the follow back option then.