### PR TITLE
Keep username case on sign up, but ignore case on uniqueness

### DIFF
--- a/spec/flows/authentication_spec.cr
+++ b/spec/flows/authentication_spec.cr
@@ -13,16 +13,13 @@ describe "Authentication flow" do
     flow.should_be_signed_in
   end
 
-  # This is to show you how to sign in as a user during tests.
-  # Use the `visit` method's `as` option in your tests to sign in as that user.
-  #
-  # Feel free to delete this once you have other tests using the 'as' option.
-  it "allows sign in through backdoor when testing" do
-    user = UserBox.create
-    flow = BaseFlow.new
+  it "maintains the username's case" do
+    flow = AuthenticationFlow.new(email: "test@example.com", username: "edWARD")
 
-    flow.visit Me::Show, as: user
-    should_be_signed_in(flow)
+    flow.sign_up "password"
+    flow.visit Me::Show
+
+    flow.el("h3", text: "edWARD").should be_on_page
   end
 end
 

--- a/src/forms/sign_up_form.cr
+++ b/src/forms/sign_up_form.cr
@@ -10,8 +10,10 @@ class SignUpForm < User::BaseForm
 
   def prepare
     validate_uniqueness_of email
-    username.value = username.value.try(&.downcase)
-    validate_uniqueness_of username, query: UserQuery.new.username.lower
+    validate_uniqueness_of(
+      downcased(username),
+      query: UserQuery.new.username.lower
+    )
     run_password_validations
     Authentic.copy_and_encrypt password, to: encrypted_password
     feed_token.value = generate_feed_token
@@ -19,5 +21,11 @@ class SignUpForm < User::BaseForm
 
   private def generate_feed_token
     Random::Secure.hex(16)
+  end
+
+  private def downcased(field : Avram::Field)
+    field.dup.tap do |downcased_field|
+      downcased_field.value = field.value.try(&.downcase)
+    end
   end
 end


### PR DESCRIPTION
I don't want case to matter when comparing username uniqueness. I.e. if
`edward` is signed up already, `EdWaRd` should not be able to sign up
also.

However, the database should remember the case sensitivity if your name
if you enter it in a special way like `edWARD`.

closes #20 