### PR TITLE
Fix flash message when inviting someone to a group

### DIFF
--- a/src/actions/memberships/create.cr
+++ b/src/actions/memberships/create.cr
@@ -4,7 +4,7 @@ class Memberships::Create < BrowserAction
   route do
     GroupInvite.create(params, group_id: group_id) do |operation, membership|
       if membership
-        flash.success = "#{operation.username} is now a member!"
+        flash.success = "#{operation.username.value} is now a member!"
         redirect Groups::Show.with(group_id)
       else
         group = GroupQuery.new.preload_users.find(1)


### PR DESCRIPTION
The success message was showing the raw field object instead of the
username's value:

this: `#<Avram::PermittedAttribute(String | Nil):0x7fefb0b31f00>`

instead of: `edwardloveall`