### PR TITLE
Use membership to get username

### DIFF
--- a/src/actions/memberships/create.cr
+++ b/src/actions/memberships/create.cr
@@ -4,7 +4,7 @@ class Memberships::Create < BrowserAction
   route do
     GroupInvite.create(params, group_id: group_id) do |operation, membership|
       if membership
-        flash.success = "#{operation.username.value} is now a member!"
+        flash.success = "#{membership.user!.username} is now a member!"
         redirect Groups::Show.with(group_id)
       else
         group = GroupQuery.new.preload_users.find(1)


### PR DESCRIPTION
Because the operation's username could _technically_ be `nil` from the type perspective, but membership can't.

I do wish there was a way to preload on an operation's model instance so I didn't have to use `!`