### PR TITLE
Separate group bits and info

### DIFF
--- a/spec/flows/group_spec.cr
+++ b/spec/flows/group_spec.cr
@@ -24,6 +24,7 @@ describe "User visits a group they are a part of" do
 
     flow.sign_in
     flow.visit_group(group.title)
+    flow.visit_group_info(group)
 
     flow.should_see_username(user1.username)
     flow.should_see_username(user2.username)
@@ -40,8 +41,8 @@ describe "User invites someone to a group" do
 
     flow.sign_in
     flow.visit_group(group.title)
+    flow.visit_group_info(group)
     flow.add_user_to_group(user: user2, group: group)
-    flow.visit_group(group.title)
 
     flow.should_see_username(user2.username)
   end

--- a/spec/support/flows/group_flow..cr
+++ b/spec/support/flows/group_flow..cr
@@ -8,6 +8,14 @@ class GroupFlow < AuthenticatedBaseFlow
     el("@group-title", text: title).click
   end
 
+  def visit_group_info(group : Group)
+    click "@group-nav-info"
+  end
+
+  def visit_group_bits(group : Group)
+    click "@group-nav-bits"
+  end
+
   def create_new_group(title : String)
     click "@new-group"
     fill_form(SaveGroup, title: title)

--- a/src/actions/feeds/show.cr
+++ b/src/actions/feeds/show.cr
@@ -52,7 +52,7 @@ class Feeds::Show < FeedAction
           "link",
           rel: "related",
           type: "text/html",
-          href: Groups::Show.with(group).url
+          href: Groups::Bits::Index.url(group)
         )
       end
       xml.element("published") { xml.text bit.created_at.to_rfc3339 }

--- a/src/actions/groups/bits/create.cr
+++ b/src/actions/groups/bits/create.cr
@@ -7,7 +7,7 @@ class Groups::Bits::Create < BrowserAction
       group_id: group.id
     ) do |operation, bit|
       if bit
-        redirect to: Groups::Show.with(group)
+        redirect to: Groups::Bits::Index.with(group)
       else
         html Groups::Bits::NewPage, save_bit: SaveBit.new, group: group
       end

--- a/src/actions/groups/bits/index.cr
+++ b/src/actions/groups/bits/index.cr
@@ -1,0 +1,8 @@
+class Groups::Bits::Index < BrowserAction
+  nested_route do
+    group = GroupQuery.find(group_id)
+    bits = BitQuery.new.for_group(group)
+
+    html Groups::Bits::IndexPage, group: group, bits: bits
+  end
+end

--- a/src/actions/groups/show.cr
+++ b/src/actions/groups/show.cr
@@ -2,12 +2,10 @@ class Groups::Show < BrowserAction
   route do
     group = GroupQuery.new.preload_users.find(group_id)
     operation = GroupInvite.new
-    bits = BitQuery.new.for_group(group)
     html(
       Groups::ShowPage,
       group: group,
       group_invite: operation,
-      group_bits: bits,
     )
   end
 end

--- a/src/components/base_component.cr
+++ b/src/components/base_component.cr
@@ -1,5 +1,2 @@
-abstract class BaseComponent
-  include Lucky::HTMLBuilder
-
-  needs view : IO::Memory
+abstract class BaseComponent < Lucky::BaseComponent
 end

--- a/src/components/groups/shared_nav.cr
+++ b/src/components/groups/shared_nav.cr
@@ -1,0 +1,12 @@
+class Groups::SharedNav < BaseComponent
+  needs group : Group
+
+  def render
+    nav class: "group" do
+      ul do
+        li { link "Info", to: Groups::Show.with(@group), flow_id: "group-nav-info" }
+        li { link "Bits", to: Groups::Bits::Index.with(@group), flow_id: "group-nav-bits" }
+      end
+    end
+  end
+end

--- a/src/css/modules/_groups.scss
+++ b/src/css/modules/_groups.scss
@@ -1,3 +1,7 @@
+nav.group {
+  margin-bottom: $spacing-large;
+}
+
 .group {
   display: block;
 }

--- a/src/pages/groups/bits/index_page.cr
+++ b/src/pages/groups/bits/index_page.cr
@@ -1,0 +1,20 @@
+class Groups::Bits::IndexPage < MainLayout
+  include Shared::BitList
+
+  needs group : Group
+  needs bits : BitQuery
+
+  def content
+    h2 @group.title
+    mount Groups::SharedNav.new(@group)
+
+    section class: "new-bit-section" do
+      link "New Bit", to: Groups::Bits::New.with(@group), flow_id: "new-group-bit-link"
+    end
+
+    section class: "group-bits-section" do
+      h2 "Bits"
+      bit_list(@bits)
+    end
+  end
+end

--- a/src/pages/groups/index_page.cr
+++ b/src/pages/groups/index_page.cr
@@ -7,7 +7,7 @@ class Groups::IndexPage < MainLayout
     ul do
       @groups.each do |group|
         li class: "group" do
-          link group.title, to: Groups::Show.with(group), flow_id: "group-title"
+          link group.title, to: Groups::Bits::Index.with(group), flow_id: "group-title"
         end
       end
     end

--- a/src/pages/groups/show_page.cr
+++ b/src/pages/groups/show_page.cr
@@ -1,15 +1,10 @@
 class Groups::ShowPage < MainLayout
-  include Shared::BitList
-
   needs group : Group
   needs group_invite : GroupInvite
-  needs group_bits : BitQuery
 
   def content
     h2 @group.title
-    section class: "new-bit-section" do
-      link "New Bit", to: Groups::Bits::New.with(@group), flow_id: "new-group-bit-link"
-    end
+    mount Groups::SharedNav.new(@group)
 
     section class: "group-members-section" do
       h2 "Members"
@@ -23,11 +18,6 @@ class Groups::ShowPage < MainLayout
     section class: "group-invite-section" do
       h2 "Invite"
       render_group_invite_form(@group_invite)
-    end
-
-    section class: "group-bits-section" do
-      h2 "Bits"
-      bit_list(@group_bits)
     end
   end
 


### PR DESCRIPTION
The bits are the list of bits, including the New Bit button

The Info is the list of members and an invite member form

Most links now take you to the group's list of bits