### PR TITLE
Add a default email

### DIFF
--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,6 +1,5 @@
-ENV["LUCKY_ENV"] = "test"
-ENV["DEV_PORT"] = "5001"
 require "spec"
+require "./support/env"
 require "lucky_flow"
 require "../src/app"
 require "./support/flows/base_flow"

--- a/spec/support/env.cr
+++ b/spec/support/env.cr
@@ -1,0 +1,3 @@
+ENV["LUCKY_ENV"] = "test"
+ENV["DEV_PORT"] = "5001"
+ENV["EMAIL_SENDER"] = "test@example.com"

--- a/src/emails/base_email.cr
+++ b/src/emails/base_email.cr
@@ -1,13 +1,14 @@
 abstract class BaseEmail < Carbon::Email
-  # You can add defaults using the 'inherited' hook
-  #
-  # Example:
-  #
-  #   macro inherited
-  #     from default_from
-  #   end
-  #
-  #   def default_from
-  #     Carbon::Address.new("support@app.com")
-  #   end
+  macro inherited
+    from default_from
+  end
+
+  def default_from
+    sender = ENV["EMAIL_SENDER"]? || raise_missing_sender_message
+    Carbon::Address.new(sender)
+  end
+
+  private def raise_missing_sender_message
+    raise "If you are sending emails, make sure you set the EMAIL_SENDER environment variable"
+  end
 end

--- a/src/emails/password_reset_request_email.cr
+++ b/src/emails/password_reset_request_email.cr
@@ -7,7 +7,6 @@ class PasswordResetRequestEmail < BaseEmail
   end
 
   to @user
-  from "myapp@support.com" # or set a default in src/emails/base_email.cr
   subject "Reset your password"
   templates html, text
 end


### PR DESCRIPTION
Fixes #64 

The `EMAIL_SENDER` environment variable will be the address that emails
(right now only the reset password email) will be sent from. Note that
since the app is currently using SendGrid it must be a verified sender
in SendGrid.

See more here:
https://sendgrid.com/docs/for-developers/sending-email/sender-identity/