### PR TITLE
Redirect to a more relevant page after sign in options

### DIFF
--- a/src/actions/password_resets/create.cr
+++ b/src/actions/password_resets/create.cr
@@ -8,7 +8,7 @@ class PasswordResets::Create < BrowserAction
         session.delete(:password_reset_token)
         sign_in user
         flash.success = "Your password has been reset"
-        redirect to: Home::Index
+        redirect to: Groups::Index
       else
         html NewPage, reset_password: operation, user_id: user_id.to_i
       end

--- a/src/actions/sign_ins/create.cr
+++ b/src/actions/sign_ins/create.cr
@@ -6,7 +6,7 @@ class SignIns::Create < BrowserAction
       if authenticated_user
         sign_in(authenticated_user)
         flash.success = "You're now signed in"
-        Authentic.redirect_to_originally_requested_path(self, fallback: Me::Show)
+        Authentic.redirect_to_originally_requested_path(self, fallback: Groups::Index)
       else
         flash.failure = "Sign in failed"
         html NewPage, operation: operation

--- a/src/actions/sign_ups/create.cr
+++ b/src/actions/sign_ups/create.cr
@@ -6,7 +6,7 @@ class SignUps::Create < BrowserAction
       if user
         flash.info = "Thanks for signing up"
         sign_in(user)
-        redirect to: Me::Show
+        redirect to: Groups::Index
       else
         flash.info = "Couldn't sign you up"
         html NewPage, operation: operation


### PR DESCRIPTION
It was confusing to land on the account page since all it has is a reset password form and your username. The thing that users probably want to do is go to their groups, or at least that's the closest guess I can direct them to.

Fixes #74 