### PR TITLE
UX improvements

### DIFF
--- a/src/actions/groups/bits/index.cr
+++ b/src/actions/groups/bits/index.cr
@@ -3,6 +3,10 @@ class Groups::Bits::Index < BrowserAction
     group = GroupQuery.find(group_id)
     bits = BitQuery.new.for_group(group)
 
-    html Groups::Bits::IndexPage, group: group, bits: bits
+    if bits.empty?
+      html Groups::Bits::IndexCoachPage, group: group
+    else
+      html Groups::Bits::IndexPage, group: group, bits: bits
+    end
   end
 end

--- a/src/actions/groups/index.cr
+++ b/src/actions/groups/index.cr
@@ -4,6 +4,10 @@ class Groups::Index < BrowserAction
       .join_users
       .where_users(UserQuery.new.id(current_user.id))
 
-    html Groups::IndexPage, groups: groups
+    if groups.empty?
+      html Groups::IndexCoachPage
+    else
+      html Groups::IndexPage, groups: groups
+    end
   end
 end

--- a/src/pages/bits/index_page.cr
+++ b/src/pages/bits/index_page.cr
@@ -8,6 +8,10 @@ class Bits::IndexPage < MainLayout
   end
 
   def content
+    para do
+      text "These bits come from the ones you posted to your "
+      link "groups", to: Groups::Index
+    end
     bit_list(bits)
   end
 end

--- a/src/pages/groups/bits/index_coach_page.cr
+++ b/src/pages/groups/bits/index_coach_page.cr
@@ -1,0 +1,21 @@
+class Groups::Bits::IndexCoachPage < MainLayout
+  needs group : Group
+
+  private def page_title
+    group.title
+  end
+
+  def content
+    h2 group.title
+    mount Groups::SharedNav.new(group)
+
+    section class: "group-bits-section section" do
+      h2 "Bits"
+      para do
+        text "There are no bits here yet, but you can create one "
+        link "here", to: Groups::Bits::New.with(group), flow_id: "new-group-bit-link"
+        text "."
+      end
+    end
+  end
+end

--- a/src/pages/groups/index_coach_page.cr
+++ b/src/pages/groups/index_coach_page.cr
@@ -1,0 +1,16 @@
+class Groups::IndexCoachPage < MainLayout
+  private def page_title
+    "My Groups"
+  end
+
+  def content
+    h2 "Groups"
+    para do
+      text "You don't belong to any groups yet. Ask someone to invite you (your username is "
+      strong @current_user.username
+      text ") or create your own:"
+    end
+
+    link "New Group", to: Groups::New, flow_id: "new-group"
+  end
+end

--- a/src/pages/me/show_page.cr
+++ b/src/pages/me/show_page.cr
@@ -6,8 +6,8 @@ class Me::ShowPage < MainLayout
   end
 
   def content
-    h3 "#{current_user.username}"
-
+    h3 "#{current_user.username}'s account"
+    page_description
     render_password_reset_form(reset_password)
   end
 
@@ -17,6 +17,17 @@ class Me::ShowPage < MainLayout
       field(op.password_confirmation) { |i| password_input i }
 
       submit "Update Password", flow_id: "update-password-button"
+    end
+  end
+
+  private def page_description
+    para do
+      text "There's not much to do here yet. But you can reset your password if you like. "
+      text "Use the navigation at the top look at your "
+      strong "groups"
+      text " or post a "
+      strong "bit"
+      text " to one of them."
     end
   end
 end


### PR DESCRIPTION
fixes #72 

The account page has more text on it so it's not as disorienting.
The group and bits pages show some helper text when they are empty.
A user's bit page shows some text that hints toward groups.