### PR TITLE
And empty feed does not crash the site

### DIFF
--- a/src/actions/groups/bits/full_feed.cr
+++ b/src/actions/groups/bits/full_feed.cr
@@ -6,8 +6,9 @@ class Groups::Bits::FullFeed < FeedAction
   get "/groups/:group_id/bits/feed/full" do
     group = GroupQuery.find(group_id)
     bits = BitQuery.new.from_group(group)
-    latest_bit = BitQuery.new.from_group(group).first
+    latest_bit = BitQuery.new.from_group(group).first?
+    last_updated = latest_bit && latest_bit.created_at || Time.unix_ms(0)
     url = Groups::Bits::FullFeed.url(group)
-    atom(bit_feed(bits, group, latest_bit.created_at, url))
+    atom(bit_feed(bits, group, last_updated, url))
   end
 end

--- a/src/actions/groups/bits/personal_feed.cr
+++ b/src/actions/groups/bits/personal_feed.cr
@@ -6,8 +6,9 @@ class Groups::Bits::PersonalFeed < FeedAction
   get "/groups/:group_id/bits/feed/personal" do
     group = GroupQuery.find(group_id)
     bits = BitQuery.new.from_group(group, without_bits_from: current_user)
-    latest_bit = BitQuery.new.from_group(group).first
+    latest_bit = BitQuery.new.from_group(group).first?
+    last_updated = latest_bit && latest_bit.created_at || Time.unix_ms(0)
     url = Groups::Bits::PersonalFeed.url(group)
-    atom(bit_feed(bits, group, latest_bit.created_at, url))
+    atom(bit_feed(bits, group, last_updated, url))
   end
 end


### PR DESCRIPTION
When a user visits a feed, the feed needs to have a last_updated date.
The date is currently calculated by the date of the most recent bit
posted to the group. If there are no bits in the group, there is no
most recent bit, and the feed would crash. Now it optionally loads the
most recent bit and uses that date, or Jan 1, 1970 if there is no bit.