### PR TITLE
Switch alternate/related link in feed

### DIFF
--- a/src/actions/mixins/bit_feed.cr
+++ b/src/actions/mixins/bit_feed.cr
@@ -48,13 +48,13 @@ module BitFeed
         "link",
         rel: "alternate",
         type: "text/html",
-        href: Groups::Bits::Index.url(group)
+        href: URI.encode(bit.url)
       )
       xml.element(
         "link",
         rel: "related",
         type: "text/html",
-        href: URI.encode(bit.url)
+        href: Groups::Bits::Index.url(group)
       )
       xml.element("published") { xml.text bit.created_at.to_rfc3339 }
       xml.element("updated") { xml.text bit.updated_at.to_rfc3339 }


### PR DESCRIPTION
An Atom feed uses the link tag to determine what URL is linked for the
item's title. I want it to go to the thing that the user linked. For
this, it should be <link rel="alternate" ... /> but I was using
rel="related" instead which links to the group on luckybits. This
switches them.